### PR TITLE
Update release flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
 name: Publish release
 
 on:
-  push:
-    branches:
-      - release
+  workflow_dispatch:
 
 jobs:
   docs:
@@ -51,6 +49,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Create a release branch
+        run: |
+          git checkout -b release
+          git push -u origin/release
       - name: Setup Java
         uses: actions/setup-java@v2
         with:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ public class ApiApplication {
 You can find the API documentation at [https://thepieterdc.github.io/dodona-api-java/](https://thepieterdc.github.io/dodona-api-java/).
 
 ## Releasing
-This process is automated via GitHub Actions. In order to make a new release, publish a commit to the `release` branch.
+This process is automated via GitHub Actions. In order to make a new release, trigger the `Release` workflow.
 
 ## Credits
 This library was created by [Pieter De Clercq](https://thepieterdc.github.io/) and [Tobiah Lissens](https://github.com/darktilrisen).


### PR DESCRIPTION
Trigger workflow manually instead of pushing a branch.