### PR TITLE
Fix blue-grey/blue-gray rename

### DIFF
--- a/api/src/main/java/io/github/thepieterdc/dodona/data/CourseColor.java
+++ b/api/src/main/java/io/github/thepieterdc/dodona/data/CourseColor.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
  * The color of a course.
  */
 public enum CourseColor {
-	BLUE_GREY("blue-grey", Color.decode("#607D8B")),
+	BLUE_GREY("blue-gray", Color.decode("#607D8B")),
 	BROWN("brown", Color.decode("#795548")),
 	CYAN("cyan", Color.decode("#00BCD4")),
 	DEEP_PURPLE("deep-purple", Color.decode("#673AB7")),

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <properties>
         <dodona.api>${basedir}</dodona.api>
         <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.13.4</jackson.version>
         <jacoco.version>0.8.8</jacoco.version>
         <jdk.version>11</jdk.version>
         <junit.version>4.13.2</junit.version>
@@ -54,7 +54,7 @@
         <maven.surefire.version>3.0.0-M7</maven.surefire.version>
         <mockito.version>4.7.0</mockito.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <random.version>1.0.0</random.version>
+        <random.version>1.0.2</random.version>
         <skip.api.tests>false</skip.api.tests>
         <skip.impl.tests>false</skip.impl.tests>
     </properties>


### PR DESCRIPTION
In https://github.com/dodona-edu/dodona/commit/470336ea758f72ad20fddb4104faf1292f348144, the colour `blue-grey` was renamed to `blue-gray`.